### PR TITLE
Slf4j

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ When a Java Record is operated with **Yorm**, a reflection inspection will came 
 - [MySql] - So far, the only database officially supported
 - [Junit 5] - For the unit tests
 - [TestContainers] - Also for the unit tests
-- [log4j] - Logging is usually useful
+- [Slf4j] - Logging is usually useful
 
 And that's it, the **Yorm** lies heavily on Java 17 Records and Reflections.
 
@@ -193,5 +193,5 @@ Apache 2.0
 [Mysql]: <https://https://www.mysql.com>
 [Junit 5]: <https://junit.org/junit5/>
 [TestContainers]: <https://www.testcontainers.org/>
-[log4j]: <https://logging.apache.org/log4j/2.x/>
+[Slf4j]: <https://www.slf4j.org/manual.html/>
    

--- a/pom.xml
+++ b/pom.xml
@@ -33,9 +33,11 @@
     <version.junit>5.8.2</version.junit>
     <version.hikaricp>5.0.0</version.hikaricp>
     <version.mysql>8.0.27</version.mysql>
-    <version.slf4j>2.7</version.slf4j>
+    <version.slf4j-api>1.7.36</version.slf4j-api>
+    <version.log4j-slf4j-impl>2.17.2</version.log4j-slf4j-impl>
     <version.testcontainers>1.16.2</version.testcontainers>
     <version.maven-surefire>3.0.0-M5</version.maven-surefire>
+    <version.log4j>2.17.2</version.log4j>
   </properties>
   <dependencies>
     <dependency>
@@ -49,9 +51,9 @@
       <version>${version.mysql}</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j-impl</artifactId>
-      <version>${version.slf4j}</version>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>${version.slf4j-api}</version>
     </dependency>
     <!-- Test Dependencies -->
     <dependency>
@@ -69,6 +71,24 @@
       <groupId>org.testcontainers</groupId>
       <artifactId>mysql</artifactId>
       <version>${version.testcontainers}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-slf4j-impl</artifactId>
+      <version>${version.log4j-slf4j-impl}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+      <version>${version.log4j}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <version>${version.log4j}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/test/resources/log4j2-test.xml
+++ b/src/test/resources/log4j2-test.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Extra logging related to initialization of Log4j.
+ Set to debug or trace if log4j initialization is failing. -->
+<Configuration status="debug">
+    <Appenders>
+        <!-- Console appender configuration -->
+        <Console name="console" target="SYSTEM_OUT">
+            <PatternLayout
+                    pattern="%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n" />
+        </Console>
+    </Appenders>
+    <Loggers>
+        <!-- Root logger referring to console appender -->
+        <Root level="info" additivity="false">
+            <AppenderRef ref="console" />
+        </Root>
+        <Logger name="org.yorm" level="info">
+            <AppenderRef ref="console"/>
+        </Logger>
+    </Loggers>
+</Configuration>


### PR DESCRIPTION
I hope you're open to collaborations, I'm sorry if not.
This is a small PR just to fix slf4j classpath configuration, it was not working and showed the message
    
`No SLF4J providers were found.`

Now works as expected, no message shown.
If you accept this PR yorm will no longer depend on log4j but will depend on slf4j, but since slf4j is more or less the standard logger in the java world right now, I think is an improvement.

All log4j dependencies are just test dependencies now.


Thanks for this library, I hope it becomes popular!  Do publish it please!
