### PR TITLE
messages in all exceptions

### DIFF
--- a/src/main/java/org/yorm/MapBuilder.java
+++ b/src/main/java/org/yorm/MapBuilder.java
@@ -50,7 +50,7 @@ public class MapBuilder {
             String objectField = findClosest(objectFields, description.fieldName());
             Optional<Method> methodOptional = methods.stream().filter(FilterPredicates.getMethod(objectField)).findFirst();
             if (methodOptional.isEmpty()) {
-                throw new YormException(String.format("Couldn't find method that matches field %s", objectField));
+                throw new YormException("Couldn't find method that matches field " + objectField);
             }
             var tuple = new YormTuple(description.fieldName(), objectField, DbType.getType(description.type()),
                 getSize(description.type()), getNullable(description.isNull()),

--- a/src/main/java/org/yorm/Yorm.java
+++ b/src/main/java/org/yorm/Yorm.java
@@ -30,7 +30,7 @@ public class Yorm {
         try {
             result = queryBuilder.save(ds, recordObj, yormTable);
         } catch (InvocationTargetException | IllegalAccessException e) {
-            throw new YormException(e.getMessage());
+            throw new YormException("Error while saving record:" + recordObj, e);
         }
         return result;
     }
@@ -38,13 +38,7 @@ public class Yorm {
     public int insert(Record recordObj) throws YormException {
         String objectName = getRecordName(recordObj);
         YormTable yormTable = map.computeIfAbsent(objectName, o -> mapBuilder.buildMap(recordObj.getClass()));
-        int result = 0;
-        try {
-            result = queryBuilder.insert(ds, recordObj, yormTable);
-        } catch (YormException e) {
-            throw new YormException(e.getMessage());
-        }
-        return result;
+        return queryBuilder.insert(ds, recordObj, yormTable);
     }
 
     public <T extends Record> void insert(List<T> recordListObj) throws YormException {
@@ -54,21 +48,14 @@ public class Yorm {
         Record recordObj = recordListObj.get(0);
         String objectName = getRecordName(recordObj);
         YormTable yormTable = map.computeIfAbsent(objectName, o -> mapBuilder.buildMap(recordObj.getClass()));
-        try {
-            queryBuilder.bulkInsert(ds, recordListObj, yormTable);
-        } catch (YormException e) {
-            throw new YormException(e.getMessage());
-        }
+        queryBuilder.bulkInsert(ds, recordListObj, yormTable);
+
     }
 
     public void update(Record recordObj) throws YormException {
         String objectName = getRecordName(recordObj);
         YormTable yormTable = map.computeIfAbsent(objectName, o -> mapBuilder.buildMap(recordObj.getClass()));
-        try {
-            queryBuilder.update(ds, recordObj, yormTable);
-        } catch (YormException e) {
-            throw new YormException(e.getMessage());
-        }
+        queryBuilder.update(ds, recordObj, yormTable);
     }
 
     public <T extends Record> T find(Class<T> recordObject, int id) throws YormException {
@@ -82,11 +69,11 @@ public class Yorm {
         String referenceObjectName = getClassName(referenceObject);
         YormTable yormTableFilter = map.computeIfAbsent(filterObjectName, o -> mapBuilder.buildMap(filterObject.getClass()));
         YormTable yormTableObject = map.computeIfAbsent(referenceObjectName, o -> mapBuilder.buildMap(referenceObject));
-        List<T> result = new ArrayList<>();
+        List<T> result;
         try {
             result = queryBuilder.get(ds, filterObject, yormTableFilter, yormTableObject);
         } catch (InvocationTargetException | IllegalAccessException | YormException e) {
-            throw new YormException(e.getMessage());
+            throw new YormException("Error while finding records with reference:" + referenceObject + " and filter:" + filterObject, e);
         }
         return result;
     }
@@ -108,7 +95,7 @@ public class Yorm {
         try {
             result = queryBuilder.get(ds, list, yormTable);
         } catch (InvocationTargetException | IllegalAccessException | YormException e) {
-            throw new YormException(e.getMessage());
+            throw new YormException("Error while finding records with list", e);
         }
         return result;
     }

--- a/src/main/java/org/yorm/db/operations/QueryDelete.java
+++ b/src/main/java/org/yorm/db/operations/QueryDelete.java
@@ -22,7 +22,7 @@ public class QueryDelete {
             preparedStatement.setInt(1, id);
             preparedStatement.executeUpdate();
         } catch (SQLException e) {
-            throw new YormException(e.getMessage());
+            throw new YormException("Error while deleting record with id:" + id + " from table:" + yormTable.getDbTable(), e);
         }
     }
 

--- a/src/main/java/org/yorm/db/operations/QueryGet.java
+++ b/src/main/java/org/yorm/db/operations/QueryGet.java
@@ -40,8 +40,8 @@ public class QueryGet {
                 loopResults(tuples, rs, values, params);
                 resultList.add((T) yormTable.getConstructor().newInstance(values));
             }
-        } catch (SQLException | InstantiationException | IllegalAccessException | InvocationTargetException | YormException e) {
-            throw new YormException(e.getMessage());
+        } catch (SQLException | InstantiationException | IllegalAccessException | InvocationTargetException e) {
+            throw new YormException("Error while getting all records from table:" + yormTable.getDbTable(), e);
         }
         return resultList;
     }
@@ -66,8 +66,8 @@ public class QueryGet {
             }
 
 
-        } catch (SQLException | InstantiationException | IllegalAccessException | InvocationTargetException | YormException e) {
-            throw new YormException(e.getMessage());
+        } catch (SQLException | InstantiationException | IllegalAccessException | InvocationTargetException e) {
+            throw new YormException("Error while getting record with id:" + id + " from table:" + yormTable.getDbTable(), e);
         }
         return (T) result;
     }
@@ -93,8 +93,8 @@ public class QueryGet {
             }
 
 
-        } catch (SQLException | InstantiationException | IllegalAccessException | InvocationTargetException | YormException e) {
-            throw new YormException(e.getMessage());
+        } catch (SQLException | InstantiationException | IllegalAccessException | InvocationTargetException e) {
+            throw new YormException("Error while deleting record with foreign id:" + id + " from table:" + yormTable.getDbTable(), e);
         }
         return resultList;
     }
@@ -129,7 +129,7 @@ public class QueryGet {
                     case DECIMAL -> preparedStatement.setBigDecimal(paramIndex, (BigDecimal) obj);
                     case DATE -> preparedStatement.setDate(paramIndex, Date.valueOf((LocalDate) obj));
                     case DATETIME, TIMESTAMP -> preparedStatement.setTimestamp(paramIndex, Timestamp.valueOf((LocalDateTime) obj));
-                    default -> throw new YormException(String.format("Couldn't find type for %s", fieldValue.fieldName()));
+                    default -> throw new YormException("Couldn't find type for " + fieldValue.fieldName());
                 }
                 paramIndex++;
             }
@@ -141,8 +141,8 @@ public class QueryGet {
                 Object result = yormTable.getConstructor().newInstance(values);
                 resultList.add((T) result);
             }
-        } catch (SQLException | InstantiationException | IllegalAccessException | InvocationTargetException | YormException e) {
-            throw new YormException(e.getMessage());
+        } catch (SQLException | InstantiationException | IllegalAccessException | InvocationTargetException e) {
+            throw new YormException("Error while filtering records with filtering list:" + filteringList + " from table:" + yormTable.getDbTable(), e);
         }
         return resultList;
     }
@@ -188,7 +188,7 @@ public class QueryGet {
                     values[params++] = ts.toLocalDateTime();
                     break;
                 default:
-                    throw new YormException(String.format("Couldn't find type for %s", tuple.dbFieldName()));
+                    throw new YormException("Couldn't find type for " + tuple.dbFieldName());
             }
         }
     }

--- a/src/main/java/org/yorm/db/operations/QuerySave.java
+++ b/src/main/java/org/yorm/db/operations/QuerySave.java
@@ -46,8 +46,8 @@ public class QuerySave {
                 paramIndex = populatePreparedStatement(tuples, paramIndex, preparedStatement, obj);
             }
             preparedStatement.executeUpdate();
-        } catch (SQLException | IllegalAccessException | YormException | InvocationTargetException e) {
-            throw new YormException(e.getMessage());
+        } catch (SQLException | IllegalAccessException | InvocationTargetException e) {
+            throw new YormException("Error while bulk inserting records:" + objList + " into table:" + yormTable.getDbTable(), e);
         }
     }
 
@@ -72,8 +72,8 @@ public class QuerySave {
             if (rs.next()) {
                 id = rs.getInt(1);
             }
-        } catch (SQLException | IllegalAccessException | YormException | InvocationTargetException e) {
-            throw new YormException(e.getMessage());
+        } catch (SQLException | IllegalAccessException | InvocationTargetException e) {
+            throw new YormException("Error while force inserting record:" + obj + " into table:" + yormTable.getDbTable(), e);
         }
         return id;
     }
@@ -100,8 +100,8 @@ public class QuerySave {
             if (rs.next()) {
                 id = rs.getInt(1);
             }
-        } catch (SQLException | InvocationTargetException | IllegalAccessException | YormException e) {
-            throw new YormException(e.getMessage());
+        } catch (SQLException | InvocationTargetException | IllegalAccessException e) {
+            throw new YormException("Error while inserting record:" + obj + " into table:" + yormTable.getDbTable(), e);
         }
         return id;
     }
@@ -126,8 +126,8 @@ public class QuerySave {
             populatePreparedStatement(tuples, paramIndex, preparedStatement, obj);
             populatePreparedStatement(keyTuples, tuples.size() + 1, preparedStatement, obj);
             preparedStatement.executeUpdate();
-        } catch (SQLException | IllegalAccessException | YormException | InvocationTargetException e) {
-            throw new YormException(e.getMessage());
+        } catch (SQLException | IllegalAccessException | InvocationTargetException e) {
+            throw new YormException("Error while updating record:" + obj + " in table:" + yormTable.getDbTable(), e);
         }
     }
 
@@ -145,7 +145,7 @@ public class QuerySave {
                 case DECIMAL -> preparedStatement.setBigDecimal(paramIndex, (BigDecimal) method.invoke(obj));
                 case DATE -> preparedStatement.setDate(paramIndex, Date.valueOf((LocalDate) method.invoke(obj)));
                 case DATETIME, TIMESTAMP -> preparedStatement.setTimestamp(paramIndex, Timestamp.valueOf((LocalDateTime) method.invoke(obj)));
-                default -> throw new YormException(String.format("Couldn't find type for %s", tuple.dbFieldName()));
+                default -> throw new YormException("Couldn't find type for " + tuple.dbFieldName());
             }
             paramIndex++;
         }

--- a/src/main/java/org/yorm/exception/YormException.java
+++ b/src/main/java/org/yorm/exception/YormException.java
@@ -2,8 +2,11 @@ package org.yorm.exception;
 
 public class YormException extends Exception {
 
-    public YormException(String errorMessage) {
-        super(errorMessage);
+    public YormException(String cause) {
+        super(cause);
     }
 
+    public YormException(String message, Throwable cause) {
+        super(message, cause);
+    }
 }


### PR DESCRIPTION
Since you have been so kind to accept my past PR...
In this one I'm making some minor changes in exceptions:
I removed all the

        } catch (YormException e) {
            throw new YormException(e.getMessage());
        }

because it is just removing the stacktrace

I wrote a message in every exception, while keeping the original cause when it existed.

I removed all `String.format` since joining strings with + is faster and creates less intermediate objects.

Of course feel free to reject the PR! It is just a sugestion

