### PR TITLE
YormTable as record

### DIFF
--- a/src/main/java/org/yorm/YormTable.java
+++ b/src/main/java/org/yorm/YormTable.java
@@ -1,37 +1,8 @@
 package org.yorm;
 
 import java.lang.reflect.Constructor;
-import java.lang.reflect.Method;
-import java.util.ArrayList;
 import java.util.List;
 
-public class YormTable {
+public record YormTable(String dbTable, List<YormTuple> tuples, Constructor<Record> constructor) {
 
-    private String dbTable;
-    private List<YormTuple> list = new ArrayList<>();
-    private Constructor<Record> constructor;
-
-    public YormTable(String dbTable) {
-        this.dbTable = dbTable;
-    }
-
-    public void add(YormTuple tuple) {
-        list.add(tuple);
-    }
-
-    public List<YormTuple> getTuples() {
-        return list.stream().toList();
-    }
-
-    public String getDbTable() {
-        return dbTable;
-    }
-
-    public Constructor<Record> getConstructor() {
-        return constructor;
-    }
-
-    public void setConstructor(Constructor<?> constructor) {
-        this.constructor = (Constructor<Record>) constructor;
-    }
 }

--- a/src/main/java/org/yorm/db/QueryBuilder.java
+++ b/src/main/java/org/yorm/db/QueryBuilder.java
@@ -37,7 +37,7 @@ public class QueryBuilder {
     }
 
     public int save(DataSource ds, Record obj, YormTable yormTable) throws InvocationTargetException, IllegalAccessException, YormException {
-        Optional<YormTuple> idField = yormTable.getTuples().stream().filter(FilterPredicates.filterAutoIncrementKey()).findFirst();
+        Optional<YormTuple> idField = yormTable.tuples().stream().filter(FilterPredicates.filterAutoIncrementKey()).findFirst();
         int idInsert = 0;
         if (idField.isEmpty()) {
             idInsert = QuerySave.forceInsert(ds, obj, yormTable);
@@ -63,18 +63,18 @@ public class QueryBuilder {
 
     public <T extends Record> List<T> get(DataSource ds, Record filterObject, YormTable yormTableFilter, YormTable yormTableObject)
         throws InvocationTargetException, IllegalAccessException, YormException {
-        String foreignKeyFilter = yormTableFilter.getDbTable() + "_id";
-        String foreignKey = yormTableFilter.getDbTable() + "_id";
-        Optional<YormTuple> yormTuple = yormTableObject.getTuples().stream().filter(t -> t.dbFieldName().equalsIgnoreCase(foreignKeyFilter)).findFirst();
+        String foreignKeyFilter = yormTableFilter.dbTable() + "_id";
+        String foreignKey = yormTableFilter.dbTable() + "_id";
+        Optional<YormTuple> yormTuple = yormTableObject.tuples().stream().filter(t -> t.dbFieldName().equalsIgnoreCase(foreignKeyFilter)).findFirst();
         if (yormTuple.isEmpty()) {
-            String foreignKeySecondAttempt = "id_" + yormTableFilter.getDbTable();
-            yormTuple = yormTableObject.getTuples().stream().filter(t -> t.dbFieldName().equalsIgnoreCase(foreignKeySecondAttempt)).findFirst();
+            String foreignKeySecondAttempt = "id_" + yormTableFilter.dbTable();
+            yormTuple = yormTableObject.tuples().stream().filter(t -> t.dbFieldName().equalsIgnoreCase(foreignKeySecondAttempt)).findFirst();
             foreignKey = foreignKeySecondAttempt;
         }
         if (yormTuple.isEmpty()) {
             return new ArrayList<>();
         }
-        Optional<YormTuple> optionalFilteringTupleId = yormTableFilter.getTuples().stream().filter(FilterPredicates.getId()).findFirst();
+        Optional<YormTuple> optionalFilteringTupleId = yormTableFilter.tuples().stream().filter(FilterPredicates.getId()).findFirst();
         if (optionalFilteringTupleId.isEmpty()) {
             return new ArrayList<>();
         }
@@ -93,7 +93,7 @@ public class QueryBuilder {
 
     private <T extends Record> List<FieldValue> getFieldValues(List<T> list, YormTable yormTable) throws IllegalAccessException, InvocationTargetException {
         List<FieldValue> fieldValueList = new ArrayList<>();
-        List<YormTuple> yormTuples = yormTable.getTuples();
+        List<YormTuple> yormTuples = yormTable.tuples();
         for (Record obj : list) {
             for (YormTuple yormTuple : yormTuples) {
                 Method method = yormTuple.method();

--- a/src/main/java/org/yorm/db/operations/QueryDelete.java
+++ b/src/main/java/org/yorm/db/operations/QueryDelete.java
@@ -15,14 +15,14 @@ public class QueryDelete {
     public static void delete(DataSource ds, YormTable yormTable, int id) throws YormException {
         StringBuilder query = new StringBuilder("DELETE ");
         query.append(" FROM ")
-            .append(yormTable.getDbTable())
+            .append(yormTable.dbTable())
             .append(" WHERE id=?");
         try (Connection connection = ds.getConnection();
             PreparedStatement preparedStatement = connection.prepareStatement(query.toString())) {
             preparedStatement.setInt(1, id);
             preparedStatement.executeUpdate();
         } catch (SQLException e) {
-            throw new YormException("Error while deleting record with id:" + id + " from table:" + yormTable.getDbTable(), e);
+            throw new YormException("Error while deleting record with id:" + id + " from table:" + yormTable.dbTable(), e);
         }
     }
 

--- a/src/main/java/org/yorm/db/operations/QueryGet.java
+++ b/src/main/java/org/yorm/db/operations/QueryGet.java
@@ -25,12 +25,12 @@ public class QueryGet {
     }
 
     public static <T extends Record> List<T> getAll(DataSource ds, YormTable yormTable) throws YormException {
-        List<YormTuple> tuples = yormTable.getTuples();
+        List<YormTuple> tuples = yormTable.tuples();
         StringBuilder query = new StringBuilder("SELECT ");
         List<T> resultList = new ArrayList<>();
         query.append(String.join(",", tuples.stream().map(YormTuple::dbFieldName).toList()))
             .append(" FROM ")
-            .append(yormTable.getDbTable());
+            .append(yormTable.dbTable());
         try (Connection connection = ds.getConnection();
             PreparedStatement preparedStatement = connection.prepareStatement(query.toString())) {
             ResultSet rs = preparedStatement.executeQuery();
@@ -38,21 +38,21 @@ public class QueryGet {
                 Object[] values = new Object[tuples.size()];
                 int params = 0;
                 loopResults(tuples, rs, values, params);
-                resultList.add((T) yormTable.getConstructor().newInstance(values));
+                resultList.add((T) yormTable.constructor().newInstance(values));
             }
         } catch (SQLException | InstantiationException | IllegalAccessException | InvocationTargetException e) {
-            throw new YormException("Error while getting all records from table:" + yormTable.getDbTable(), e);
+            throw new YormException("Error while getting all records from table:" + yormTable.dbTable(), e);
         }
         return resultList;
     }
 
     public static <T extends Record> T getById(DataSource ds, YormTable yormTable, int id) throws YormException {
-        List<YormTuple> tuples = yormTable.getTuples();
+        List<YormTuple> tuples = yormTable.tuples();
         StringBuilder query = new StringBuilder("SELECT ");
         Object result = null;
         query.append(String.join(",", tuples.stream().map(YormTuple::dbFieldName).toList()))
             .append(" FROM ")
-            .append(yormTable.getDbTable())
+            .append(yormTable.dbTable())
             .append(" WHERE id=?");
         try (Connection connection = ds.getConnection();
             PreparedStatement preparedStatement = connection.prepareStatement(query.toString())) {
@@ -62,23 +62,23 @@ public class QueryGet {
                 Object[] values = new Object[tuples.size()];
                 int params = 0;
                 loopResults(tuples, rs, values, params);
-                result = yormTable.getConstructor().newInstance(values);
+                result = yormTable.constructor().newInstance(values);
             }
 
 
         } catch (SQLException | InstantiationException | IllegalAccessException | InvocationTargetException e) {
-            throw new YormException("Error while getting record with id:" + id + " from table:" + yormTable.getDbTable(), e);
+            throw new YormException("Error while getting record with id:" + id + " from table:" + yormTable.dbTable(), e);
         }
         return (T) result;
     }
 
     public static <T extends Record> List<T> getByForeignId(DataSource ds, YormTable yormTable, String fieldName, int id) throws YormException {
         List<T> resultList = new ArrayList<>();
-        List<YormTuple> tuples = yormTable.getTuples();
+        List<YormTuple> tuples = yormTable.tuples();
         StringBuilder query = new StringBuilder("SELECT ");
         query.append(String.join(",", tuples.stream().map(YormTuple::dbFieldName).toList()))
             .append(" FROM ")
-            .append(yormTable.getDbTable())
+            .append(yormTable.dbTable())
             .append(" WHERE " + fieldName + "=?");
         try (Connection connection = ds.getConnection();
             PreparedStatement preparedStatement = connection.prepareStatement(query.toString())) {
@@ -88,13 +88,13 @@ public class QueryGet {
                 Object[] values = new Object[tuples.size()];
                 int params = 0;
                 loopResults(tuples, rs, values, params);
-                Object result = yormTable.getConstructor().newInstance(values);
+                Object result = yormTable.constructor().newInstance(values);
                 resultList.add((T) result);
             }
 
 
         } catch (SQLException | InstantiationException | IllegalAccessException | InvocationTargetException e) {
-            throw new YormException("Error while deleting record with foreign id:" + id + " from table:" + yormTable.getDbTable(), e);
+            throw new YormException("Error while deleting record with foreign id:" + id + " from table:" + yormTable.dbTable(), e);
         }
         return resultList;
     }
@@ -102,11 +102,11 @@ public class QueryGet {
     public static <T extends Record> List<T> getFiltering(DataSource ds, YormTable yormTable, List<FieldValue> filteringList) throws YormException {
         String op = " ? OR";
         List<T> resultList = new ArrayList<>();
-        List<YormTuple> tuples = yormTable.getTuples();
+        List<YormTuple> tuples = yormTable.tuples();
         StringBuilder query = new StringBuilder("SELECT ");
         query.append(String.join(",", tuples.stream().map(YormTuple::dbFieldName).toList()))
             .append(" FROM ")
-            .append(yormTable.getDbTable());
+            .append(yormTable.dbTable());
         if (!filteringList.isEmpty()) {
             query.append(" WHERE ")
                 .append(String.join(" ", filteringList.stream().map(fv -> fv.fieldName() + " " + fv.whereOperator().getOperor() + op).toList()));
@@ -138,11 +138,11 @@ public class QueryGet {
                 Object[] values = new Object[tuples.size()];
                 int params = 0;
                 loopResults(tuples, rs, values, params);
-                Object result = yormTable.getConstructor().newInstance(values);
+                Object result = yormTable.constructor().newInstance(values);
                 resultList.add((T) result);
             }
         } catch (SQLException | InstantiationException | IllegalAccessException | InvocationTargetException e) {
-            throw new YormException("Error while filtering records with filtering list:" + filteringList + " from table:" + yormTable.getDbTable(), e);
+            throw new YormException("Error while filtering records with filtering list:" + filteringList + " from table:" + yormTable.dbTable(), e);
         }
         return resultList;
     }

--- a/src/main/java/org/yorm/db/operations/QuerySave.java
+++ b/src/main/java/org/yorm/db/operations/QuerySave.java
@@ -26,9 +26,9 @@ public class QuerySave {
 
     public static <T extends Record> void bulkInsert(DataSource ds, List<T> objList, YormTable yormTable) throws YormException {
         String op = "?,";
-        List<YormTuple> tuples = yormTable.getTuples();
+        List<YormTuple> tuples = yormTable.tuples();
         StringBuilder query = new StringBuilder("INSERT INTO ");
-        query.append(yormTable.getDbTable())
+        query.append(yormTable.dbTable())
             .append(" (")
             .append(String.join(",", tuples.stream().map(YormTuple::dbFieldName).toList()))
             .append(") VALUES ");
@@ -47,16 +47,16 @@ public class QuerySave {
             }
             preparedStatement.executeUpdate();
         } catch (SQLException | IllegalAccessException | InvocationTargetException e) {
-            throw new YormException("Error while bulk inserting records:" + objList + " into table:" + yormTable.getDbTable(), e);
+            throw new YormException("Error while bulk inserting records:" + objList + " into table:" + yormTable.dbTable(), e);
         }
     }
 
     public static int forceInsert(DataSource ds, Record obj, YormTable yormTable) throws YormException {
         String op = "?,";
         int id = 0;
-        List<YormTuple> tuples = yormTable.getTuples();
+        List<YormTuple> tuples = yormTable.tuples();
         StringBuilder query = new StringBuilder("INSERT INTO ");
-        query.append(yormTable.getDbTable())
+        query.append(yormTable.dbTable())
             .append(" (")
             .append(String.join(",", tuples.stream().map(YormTuple::dbFieldName).toList()))
             .append(") VALUES (")
@@ -73,7 +73,7 @@ public class QuerySave {
                 id = rs.getInt(1);
             }
         } catch (SQLException | IllegalAccessException | InvocationTargetException e) {
-            throw new YormException("Error while force inserting record:" + obj + " into table:" + yormTable.getDbTable(), e);
+            throw new YormException("Error while force inserting record:" + obj + " into table:" + yormTable.dbTable(), e);
         }
         return id;
     }
@@ -82,9 +82,9 @@ public class QuerySave {
         String op = "?,";
         int id = 0;
         Predicate<YormTuple> predicateFilterOutPrimaryKeys = FilterPredicates.filterOutPrimaryKeys();
-        List<YormTuple> tuples = yormTable.getTuples().stream().filter(predicateFilterOutPrimaryKeys).toList();
+        List<YormTuple> tuples = yormTable.tuples().stream().filter(predicateFilterOutPrimaryKeys).toList();
         StringBuilder query = new StringBuilder("INSERT INTO ");
-        query.append(yormTable.getDbTable())
+        query.append(yormTable.dbTable())
             .append(" (")
             .append(String.join(",", tuples.stream().map(YormTuple::dbFieldName).toList()))
             .append(") VALUES (")
@@ -101,7 +101,7 @@ public class QuerySave {
                 id = rs.getInt(1);
             }
         } catch (SQLException | InvocationTargetException | IllegalAccessException e) {
-            throw new YormException("Error while inserting record:" + obj + " into table:" + yormTable.getDbTable(), e);
+            throw new YormException("Error while inserting record:" + obj + " into table:" + yormTable.dbTable(), e);
         }
         return id;
     }
@@ -109,11 +109,11 @@ public class QuerySave {
     public static void update(DataSource ds, Record obj, YormTable yormTable) throws YormException {
         String op = " = ?,";
         String op2 = "=? AND ";
-        List<YormTuple> tuples = yormTable.getTuples();
+        List<YormTuple> tuples = yormTable.tuples();
         Predicate<YormTuple> predicateFilterKeepKeys = FilterPredicates.filterKeepKeys();
         List<YormTuple> keyTuples = tuples.stream().filter(predicateFilterKeepKeys).toList();
         StringBuilder query = new StringBuilder("UPDATE ");
-        query.append(yormTable.getDbTable())
+        query.append(yormTable.dbTable())
             .append(" SET ")
             .append(String.join(op, tuples.stream().map(YormTuple::dbFieldName).toList()))
             .append("=?");
@@ -127,7 +127,7 @@ public class QuerySave {
             populatePreparedStatement(keyTuples, tuples.size() + 1, preparedStatement, obj);
             preparedStatement.executeUpdate();
         } catch (SQLException | IllegalAccessException | InvocationTargetException e) {
-            throw new YormException("Error while updating record:" + obj + " in table:" + yormTable.getDbTable(), e);
+            throw new YormException("Error while updating record:" + obj + " in table:" + yormTable.dbTable(), e);
         }
     }
 

--- a/src/test/java/org/yorm/YormTest.java
+++ b/src/test/java/org/yorm/YormTest.java
@@ -39,7 +39,7 @@ class YormTest {
         MapBuilder mp = new MapBuilder(ds);
         YormTable map = mp.buildMap(Person.class);
         assertNotNull(map);
-        List<YormTuple> tuples = map.getTuples();
+        List<YormTuple> tuples = map.tuples();
         assertEquals(5, tuples.size());
         YormTuple tuple0 = tuples.get(0);
         assertEquals("id", tuple0.dbFieldName());


### PR DESCRIPTION
Here I am once again asking for your merge.

This is another minor change: I transformed the class YormTable into a record. This enables future optimizations, like pre generation of SQL sentences, having extra fields ` string select = "SELECT FIELD1, FIELD2 from TABLE". ` calculated just once.

I haven't got that far.

One question: Shouldn't the method buildMap rethrow  exceptions on any case in line 45? If yorm can not analyze a table, I think it will be better if fails as fast as possible.
