### PR TITLE
Return on delete

### DIFF
--- a/src/main/java/org/yorm/Yorm.java
+++ b/src/main/java/org/yorm/Yorm.java
@@ -108,10 +108,10 @@ public class Yorm {
         return recordObj.getClass().getSimpleName().toLowerCase(Locale.ROOT);
     }
 
-    public <T extends Record> void delete(Class<T> recordObject, int id) throws YormException {
+    public <T extends Record> boolean delete(Class<T> recordObject, int id) throws YormException {
         String objectName = getClassName(recordObject);
         YormTable yormTable = getTable(objectName, recordObject);
-        queryBuilder.delete(ds, yormTable, id);
+        return queryBuilder.delete(ds, yormTable, id);
     }
 
     private <T extends Record> YormTable getTable(String objectName, Class<T> recordObject) throws YormException {

--- a/src/main/java/org/yorm/db/QueryBuilder.java
+++ b/src/main/java/org/yorm/db/QueryBuilder.java
@@ -53,8 +53,8 @@ public class QueryBuilder {
         return idInsert;
     }
 
-    public void delete(DataSource ds, YormTable yormTable, int id) throws YormException {
-        QueryDelete.delete(ds, yormTable, id);
+    public boolean delete(DataSource ds, YormTable yormTable, int id) throws YormException {
+        return QueryDelete.delete(ds, yormTable, id);
     }
 
     public <T extends Record> T get(DataSource ds, YormTable yormTable, int id) throws YormException {

--- a/src/main/java/org/yorm/db/operations/QueryDelete.java
+++ b/src/main/java/org/yorm/db/operations/QueryDelete.java
@@ -12,7 +12,7 @@ public class QueryDelete {
     private QueryDelete() {
     }
 
-    public static void delete(DataSource ds, YormTable yormTable, int id) throws YormException {
+    public static boolean delete(DataSource ds, YormTable yormTable, int id) throws YormException {
         StringBuilder query = new StringBuilder("DELETE ");
         query.append(" FROM ")
             .append(yormTable.dbTable())
@@ -20,7 +20,7 @@ public class QueryDelete {
         try (Connection connection = ds.getConnection();
             PreparedStatement preparedStatement = connection.prepareStatement(query.toString())) {
             preparedStatement.setInt(1, id);
-            preparedStatement.executeUpdate();
+            return preparedStatement.executeUpdate() > 0;
         } catch (SQLException e) {
             throw new YormException("Error while deleting record with id:" + id + " from table:" + yormTable.dbTable(), e);
         }

--- a/src/test/java/org/yorm/YormTest.java
+++ b/src/test/java/org/yorm/YormTest.java
@@ -1,11 +1,5 @@
 package org.yorm;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -21,6 +15,8 @@ import org.yorm.records.Invoice;
 import org.yorm.records.Person;
 import org.yorm.util.DbType;
 import org.yorm.utils.TestConnectionFactory;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 class YormTest {
@@ -201,9 +197,12 @@ class YormTest {
     @Test
     @Order(12)
     void delete() throws YormException {
-        yorm.delete(Person.class, 1);
+        var somethingWasDeleted = yorm.delete(Person.class, 1);
+        assertTrue(somethingWasDeleted);
         Person personResult = yorm.find(Person.class, 1);
         assertNull(personResult);
+        somethingWasDeleted = yorm.delete(Person.class, 1);
+        assertFalse(somethingWasDeleted);
     }
 
     @Test

--- a/src/test/resources/log4j2-test.xml
+++ b/src/test/resources/log4j2-test.xml
@@ -14,7 +14,7 @@
         <Root level="info" additivity="false">
             <AppenderRef ref="console" />
         </Root>
-        <Logger name="org.yorm" level="info">
+        <Logger name="org.yorm" level="debug" additivity="false">
             <AppenderRef ref="console"/>
         </Logger>
     </Loggers>


### PR DESCRIPTION
yorm.delete returns true if something was deleted.

Also, if you configure a logger in debug for org.yorm, you will see mapping info, something like 
DEBUG MapBuilder:50 - Record:org.yorm.records.Company mapped to table:company
DEBUG MapBuilder:52 -   Field:id mapped to column:id type:INT nullable:false
DEBUG MapBuilder:52 -   Field:name mapped to column:name type:VARCHAR nullable:false
DEBUG MapBuilder:52 -   Field:countryCode mapped to column:country_code type:VARCHAR nullable:false
DEBUG MapBuilder:52 -   Field:date mapped to column:creation_date type:DATE nullable:false
DEBUG MapBuilder:52 -   Field:debt mapped to column:debt type:FLOAT nullable:false
DEBUG MapBuilder:52 -   Field:isActive mapped to column:is_active type:TINYINT nullable:false

I thought it can be useful, and it is easy to disable, so I went for it.